### PR TITLE
Simulate Azure issueToken auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project exposes Microsoft Edge's free text-to-speech service with endpoints
 - **Azure-Compatible Endpoints**
   - `POST /cognitiveservices/v1` for text-to-speech using SSML.
   - `GET /cognitiveservices/voices/list` to retrieve available voices.
+  - `POST /sts/v1.0/issueToken` to exchange an API key for a short‑lived bearer token.
 - **Multiple Audio Formats** – Specify the desired format using the `X-Microsoft-OutputFormat` header (mp3, wav, flac, opus, aac).
 - **Runs with Python** – No Docker required. Uses the `edge-tts` library under the hood.
 
@@ -51,10 +52,18 @@ python app/server.py
 
 ## Usage
 
+### Retrieve an Access Token
+
+```bash
+TOKEN=$(curl -s -X POST \
+  -H "Ocp-Apim-Subscription-Key: YOUR_KEY" \
+  http://localhost:5050/sts/v1.0/issueToken)
+```
+
 ### List Voices
 
 ```bash
-curl -H "Authorization: Bearer YOUR_KEY" \
+curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:5050/cognitiveservices/voices/list
 ```
 
@@ -62,7 +71,7 @@ curl -H "Authorization: Bearer YOUR_KEY" \
 
 ```bash
 curl -X POST "http://localhost:5050/cognitiveservices/v1" \
-  -H "Authorization: Bearer YOUR_KEY" \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/ssml+xml" \
   -H "X-Microsoft-OutputFormat: audio-24khz-48kbitrate-mono-mp3" \
   -d '<speak version="1.0" xml:lang="en-US"><voice name="en-US-AvaNeural">Hello from Azure compatible API</voice></speak>' \

--- a/app/server.py
+++ b/app/server.py
@@ -10,12 +10,18 @@ from xml.etree import ElementTree as ET
 from config import DEFAULT_CONFIGS
 from handle_text import prepare_tts_input_with_context
 from tts_handler import generate_speech, get_voices
-from utils import getenv_bool, require_api_key, AUDIO_FORMAT_MIME_TYPES, DETAILED_ERROR_LOGGING
+from utils import (
+    getenv_bool,
+    require_api_key,
+    AUDIO_FORMAT_MIME_TYPES,
+    DETAILED_ERROR_LOGGING,
+    generate_token,
+    API_KEY,
+)
 
 app = Flask(__name__)
 load_dotenv()
 
-API_KEY = os.getenv('API_KEY', DEFAULT_CONFIGS["API_KEY"])
 PORT = int(os.getenv('PORT', str(DEFAULT_CONFIGS["PORT"])))
 
 DEFAULT_VOICE = os.getenv('DEFAULT_VOICE', DEFAULT_CONFIGS["DEFAULT_VOICE"])
@@ -85,6 +91,16 @@ def azure_voices_list():
     language = request.args.get('language') or request.args.get('locale')
     voices = get_voices(language if language else None)
     return jsonify(voices)
+
+
+@app.route('/sts/v1.0/issueToken', methods=['POST'])
+def issue_token():
+    """Simulate Azure issueToken endpoint."""
+    subs_key = request.headers.get('Ocp-Apim-Subscription-Key') or request.headers.get('Subscription-Key')
+    if subs_key != API_KEY:
+        return '', 401
+    token = generate_token()
+    return token, 200, {'Content-Type': 'text/plain'}
 
 
 print("Azure Voices API compatible server")


### PR DESCRIPTION
## Summary
- add `/sts/v1.0/issueToken` endpoint to issue short-lived tokens
- store tokens server-side and validate in `require_api_key`
- document token retrieval in README

## Testing
- `python -m py_compile app/server.py app/utils.py`
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_689d0f724d18832787f40cd1e291832a