### PR TITLE
Use Ocp-Apim-Subscription-Key header

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project exposes Microsoft Edge's free text-to-speech service with endpoints
 - **Azure-Compatible Endpoints**
   - `POST /cognitiveservices/v1` for text-to-speech using SSML.
   - `GET /cognitiveservices/voices/list` to retrieve available voices.
-  - `POST /sts/v1.0/issueToken` to exchange an API key for a short‑lived bearer token.
+  - `POST /sts/v1.0/issueToken` to exchange an `Ocp-Apim-Subscription-Key` for a short‑lived bearer token.
 - **Multiple Audio Formats** – Specify the desired format using the `X-Microsoft-OutputFormat` header (mp3, wav, flac, opus, aac).
 - **Runs with Python** – No Docker required. Uses the `edge-tts` library under the hood.
 
@@ -31,7 +31,7 @@ pip install -r requirements.txt
 Create a `.env` file in the project root:
 
 ```env
-API_KEY=your_api_key_here
+OCP_APIM_SUBSCRIPTION_KEY=your_subscription_key_here
 PORT=5050
 
 DEFAULT_VOICE=en-US-AvaNeural

--- a/app/config.py
+++ b/app/config.py
@@ -3,7 +3,7 @@
 DEFAULT_CONFIGS = {
     # Server settings
     "PORT": 5050,
-    "API_KEY": 'your_api_key_here',  # Fallback API key
+    "SUBSCRIPTION_KEY": 'your_subscription_key_here',  # Fallback Ocp-Apim-Subscription-Key
 
     # TTS settings
     "DEFAULT_VOICE": 'en-US-AvaNeural',

--- a/app/server.py
+++ b/app/server.py
@@ -16,7 +16,7 @@ from utils import (
     AUDIO_FORMAT_MIME_TYPES,
     DETAILED_ERROR_LOGGING,
     generate_token,
-    API_KEY,
+    SUBSCRIPTION_KEY,
 )
 
 app = Flask(__name__)
@@ -97,7 +97,7 @@ def azure_voices_list():
 def issue_token():
     """Simulate Azure issueToken endpoint."""
     subs_key = request.headers.get('Ocp-Apim-Subscription-Key') or request.headers.get('Subscription-Key')
-    if subs_key != API_KEY:
+    if subs_key != SUBSCRIPTION_KEY:
         return '', 401
     token = generate_token()
     return token, 200, {'Content-Type': 'text/plain'}

--- a/app/utils.py
+++ b/app/utils.py
@@ -17,7 +17,7 @@ def getenv_bool(name: str, default: bool = False) -> bool:
     # For typical usage, the config default (passed at call site) is preferred.
     return os.getenv(name, str(default)).lower() in ("yes", "y", "true", "1", "t")
 
-API_KEY = os.getenv('API_KEY', DEFAULT_CONFIGS["API_KEY"])
+SUBSCRIPTION_KEY = os.getenv('OCP_APIM_SUBSCRIPTION_KEY', DEFAULT_CONFIGS["SUBSCRIPTION_KEY"])
 REQUIRE_API_KEY = getenv_bool('REQUIRE_API_KEY', DEFAULT_CONFIGS["REQUIRE_API_KEY"])
 DETAILED_ERROR_LOGGING = getenv_bool('DETAILED_ERROR_LOGGING', DEFAULT_CONFIGS["DETAILED_ERROR_LOGGING"])
 
@@ -31,7 +31,7 @@ def generate_token() -> str:
     return token
 
 def is_valid_token(token: str) -> bool:
-    if token == API_KEY:
+    if token == SUBSCRIPTION_KEY:
         return True
     expiry = TOKENS.get(token)
     if expiry and expiry > time.time():
@@ -47,10 +47,10 @@ def require_api_key(f):
             return f(*args, **kwargs)
         auth_header = request.headers.get('Authorization')
         if not auth_header or not auth_header.startswith('Bearer '):
-            return jsonify({"error": "Missing or invalid API key"}), 401
+            return jsonify({"error": "Missing or invalid Ocp-Apim-Subscription-Key"}), 401
         token = auth_header.split('Bearer ')[1]
         if not is_valid_token(token):
-            return jsonify({"error": "Invalid or expired API key"}), 401
+            return jsonify({"error": "Invalid or expired Ocp-Apim-Subscription-Key"}), 401
         return f(*args, **kwargs)
     return decorated_function
 


### PR DESCRIPTION
## Summary
- replace API key wording with `Ocp-Apim-Subscription-Key`
- rename default configuration and environment variables to `OCP_APIM_SUBSCRIPTION_KEY`
- update access checks and error messages to use subscription key terminology

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_689d1902738483278b19a108a70070ce